### PR TITLE
added link to RapidAPI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,3 +58,4 @@ resolutions: [
 ```
 
 欢迎点评→[issue](https://github.com/xCss/bing/issues)
+Test on [RapidAPI](https://rapidapi.com/package/BingSearch?utm_source=BingGitHub&utm_medium=button)


### PR DESCRIPTION
I've added a link in your README to Bing's functions page in RapidAPI. I've done this for a few Bing SDKs to help those who are reading the READMEs, understand and test the API before use.